### PR TITLE
fix(SafariNomoduleFixPlugin):missing a "/" character

### DIFF
--- a/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
@@ -41,8 +41,14 @@ class SafariNomoduleFixPlugin {
           }
         } else {
           // inject the fix as an external script
+          let urlPath = compilation.options.output.publicPath
+          let protocol = ''
+          if (/:\/\//.test(urlPath)) {
+            [protocol, urlPath] = urlPath.split('://')
+            protocol = `${protocol}://`
+          }
           const safariFixPath = path.join(this.jsDirectory, 'safari-nomodule-fix.js')
-          const fullSafariFixPath = path.join(compilation.options.output.publicPath, safariFixPath)
+          const fullSafariFixPath = `${protocol}${path.join(urlPath, safariFixPath)}`
           compilation.assets[safariFixPath] = new RawSource(safariFix)
           scriptTag = {
             tagName: 'script',


### PR DESCRIPTION
When using the publicPath option, if you use https:// or http://, the resulting fullSafariFixPath will be missing a /character (e.g. http://example.com/... will become http:/example.com...) This is commit to fix this issue.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
